### PR TITLE
Change from deprecated msgpack-python to msgpack package

### DIFF
--- a/miio/miio_server.py
+++ b/miio/miio_server.py
@@ -64,7 +64,7 @@ def socket_incoming_connection(socket, address):
 
     sockets[address] = socket
 
-    unpacker = Unpacker(encoding='utf-8')
+    unpacker = Unpacker()
     while True:
         data = socket.recv(4096)
 
@@ -85,7 +85,7 @@ def socket_msg_sender(sockets, q):
     while True:
         msg = q.get()
         if isinstance(msg, OutMsg) and msg.to in sockets:
-            sockets[msg.to].sendall(msgpack.packb(msg, use_bin_type=True))
+            sockets[msg.to].sendall(msgpack.packb(msg))
             logger.debug('send reply %s', msg.to)
 
 

--- a/miio/test.py
+++ b/miio/test.py
@@ -20,12 +20,12 @@ args = parser.parse_args()
 print('test: trying connect to %s:%s' % (args.host, args.port))
 
 client = socket.create_connection((args.host, args.port))
-client.sendall(msgpack.packb(['status'], use_bin_type=True))
+client.sendall(msgpack.packb(['status']))
 
 print("test: sent request to server [status]")
 print("test: reading response...")
 
-unpacker = Unpacker(encoding='utf-8')
+unpacker = Unpacker()
 
 while True:
     data = client.recv(4096)

--- a/plugin.py
+++ b/plugin.py
@@ -141,7 +141,7 @@ class BasePlugin:
         self.subHost = None
         self.subPort = None
         self.tcpConn = None
-        self.unpacker = msgpack.Unpacker(encoding='utf-8')
+        self.unpacker = msgpack.Unpacker()
 
     def onStart(self):
         if Parameters['Mode4'] == 'Debug':
@@ -498,7 +498,7 @@ class BasePlugin:
         cmd = [cmd_name]
         if cmd_value: cmd.append(cmd_value)
         try:
-            self.tcpConn.Send(msgpack.packb(cmd, use_bin_type=True))
+            self.tcpConn.Send(msgpack.packb(cmd))
             return True
         except msgpack.PackException as e:
             Domoticz.Error('Pack exception [%s]' % str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gevent
-msgpack-python
+msgpack
 python-miio


### PR DESCRIPTION
The msgpack-python package is deprecated, and its name is changed to msgpack.
The msgpack package is now installed, and code changes are included to resolve the breaking changes.